### PR TITLE
Force overriden TabExpansion2 to be invoked

### DIFF
--- a/TabExpansionPlusPlus.psm1
+++ b/TabExpansionPlusPlus.psm1
@@ -914,7 +914,7 @@ function global:TabExpansion2
         # No results, if this module has overridden another TabExpansion2 function, call it
         # but only if it's not the built-in function (which we assume if function isn't
         # defined in a file.
-        if ($oldTabExpansion2 -ne $null -and $oldTabExpansion2.File -ne $null)
+        if ($oldTabExpansion2 -ne $null -and ($oldTabExpansion2.File -ne $null -or $global:customTabExpansion2))
         {
             return (& $oldTabExpansion2 @PSBoundParameters)
         }


### PR DESCRIPTION
It's very common to override $function:tabexpansion2 without using a file. 
Currently TabExpansionPlusPlus will drop the customization if it is not a file, this new global variable would force it to load.

To use, set `$global:customTabExpansion2 = $true` before importing

Example:
Gulp has a script that will add tab completion by running:
`Invoke-Expression ((gulp --completion=powershell) -join [System.Environment]::NewLine)`